### PR TITLE
Fix scoring bug and add tests

### DIFF
--- a/app/src/main/java/com/foodprint/scanner/domain/ScoringService.kt
+++ b/app/src/main/java/com/foodprint/scanner/domain/ScoringService.kt
@@ -7,6 +7,8 @@ class ScoringService {
         val processed = items.count { it.category.equals("Processed", ignoreCase = true) }
         val ultraProcessed = items.count { it.category.equals("Ultra-Processed", ignoreCase = true) }
         val total = items.size
-        return ((natural * 2 + processed * 1 + ultraProcessed * 0).toDouble() / total) * 100
+        // Maximum score per item is 2, so divide by (total * 2) to keep result in 0..100
+        val weightedSum = natural * 2 + processed
+        return (weightedSum.toDouble() / (total * 2)) * 100
     }
 }

--- a/app/src/test/java/com/foodprint/scanner/domain/ScoringServiceTest.kt
+++ b/app/src/test/java/com/foodprint/scanner/domain/ScoringServiceTest.kt
@@ -1,0 +1,22 @@
+package com.foodprint.scanner.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ScoringServiceTest {
+    @Test
+    fun calculateScore_allNatural_returns100() {
+        val items = listOf(
+            ItemClassification("Apple", "Natural", 1.0f),
+            ItemClassification("Banana", "Natural", 1.0f)
+        )
+        val score = ScoringService().calculateScore(items)
+        assertEquals(100.0, score, 0.001)
+    }
+
+    @Test
+    fun calculateScore_emptyList_returns0() {
+        val score = ScoringService().calculateScore(emptyList())
+        assertEquals(0.0, score, 0.001)
+    }
+}


### PR DESCRIPTION
## Summary
- correct `ScoringService.calculateScore` so results are within 0..100
- add unit test for `ScoringService`

## Testing
- `./gradlew test --no-daemon --console=plain` *(fails: Cannot find Java installation matching language version 17)*

------
https://chatgpt.com/codex/tasks/task_e_6878a0811a98832d982e3d8429de1e89